### PR TITLE
Add devnet support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceRoot}/packages/ui/src"
+    },
+    {
+      "name": "keypering",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}/packages/app",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+      "windows": {
+        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+      },
+      "args": ["."],
+      "outputCapture": "std",
+      "env": {
+        "NODE_ENV": "development"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ Keypering consists of 3 components:
 - [How to Develop a CKB DApp with Keypering (Video, Chinese + English Subtitles)](https://youtu.be/i-gQ0enK5cY)
 - [How to Develop a CKB DApp with Keypering (Slides)](https://docs.google.com/presentation/d/1bswEhjSYwZZnUCF4rRL5x5vfOVXO_kDlbjsojsG94w8/edit?usp=sharing)
 
+# Develop in devnet
+
+1. Clone [perkins-tent](https://github.com/xxuejie/perkins-tent)
+2. Run `docker run -e CKB_NETWORK=dev --rm -p 8114:9115 -v ~/.ckb-docker-devnet:/data xxuejie/perkins-tent`
+3. Go to `~/.ckb-docker-devnet/confs/nginx.conf` change `location = /indexer_rpc` to `location = /indexer`
+4. Open keypering setting page then click Rich Node RPC setting icon, set `http://localhost:8114/indexer` in devent input
+5. Finish!
+6. If you want to run a miner, append ` miner: ckb miner -C /data/ckb-data` to `~/.ckb-docker-devnet/confs/Procfile`
+
 # Resources
 
 - [Keypering Manual](https://nervosnetwork.github.io/keypering/#/manual) - User Guide of Keypering

--- a/packages/app/src/setting/networks.ts
+++ b/packages/app/src/setting/networks.ts
@@ -1,5 +1,5 @@
 import type { Channel } from '@keypering/specs'
-import { MAINNET_ID, TESTNET_ID, DEVNET_ID, RICH_NODE_MAINNET_INDEXER_URL, RICH_NODE_TESTNET_INDEXER_URL } from '../utils'
+import { MAINNET_ID, TESTNET_ID, DEVNET_ID, RICH_NODE_MAINNET_INDEXER_URL, RICH_NODE_TESTNET_INDEXER_URL, RICH_NODE_DEVNET_INDEXER_URL } from '../utils'
 const networks = new Map<Channel.NetworkId, { name: string, url: string }>([
   [
     MAINNET_ID,
@@ -19,7 +19,7 @@ const networks = new Map<Channel.NetworkId, { name: string, url: string }>([
     DEVNET_ID,
     {
       name: 'devnet',
-      url: RICH_NODE_TESTNET_INDEXER_URL,
+      url: RICH_NODE_DEVNET_INDEXER_URL,
     }
   ]
 ])

--- a/packages/app/src/setting/scripts.ts
+++ b/packages/app/src/setting/scripts.ts
@@ -3,6 +3,7 @@ import { Secp256k1LockScript } from '@nervosnetwork/keyper-container/lib/locks/s
 import { AnyPayLockScript } from '@nervosnetwork/keyper-container/lib/locks/anyone-can-pay'
 import {
   SECP256K1_BLAKE160_CODE_HASH,
+  SECP256K1_BLAKE160_DEVNET_TX_HASH,
   SECP256K1_BLAKE160_MAINNET_TX_HASH,
   SECP256K1_BLAKE160_TESTNET_TX_HASH,
   ANYONE_CAN_PAY_CODE_HASH,
@@ -42,4 +43,16 @@ const testnetScripts: LockScript[] = [
     },
   ]),
 ]
-export default { mainnetScripts, testnetScripts }
+
+const devnetScripts: LockScript[] = [
+  new Secp256k1LockScript(SECP256K1_BLAKE160_CODE_HASH, 'type', [
+    {
+      outPoint: {
+        txHash: SECP256K1_BLAKE160_DEVNET_TX_HASH,
+        index: '0x0',
+      },
+      depType: 'depGroup',
+    },
+  ])
+]
+export default { mainnetScripts, testnetScripts, devnetScripts }

--- a/packages/app/src/setting/service.ts
+++ b/packages/app/src/setting/service.ts
@@ -82,11 +82,21 @@ export const getSetting = () => {
     }
   })
 
-  const scriptsToShow = setting.networkId === MAINNET_ID
-    ? systemScripts.mainnetScripts
-    : setting.networkId === TESTNET_ID
-      ? systemScripts.testnetScripts
-      : []
+  let scriptsToShow: LockScript[];
+
+  switch(setting.networkId) {
+    case MAINNET_ID:
+      scriptsToShow = systemScripts.mainnetScripts
+      break;
+    case TESTNET_ID:
+      scriptsToShow = systemScripts.testnetScripts
+      break;
+    case DEVNET_ID:
+      scriptsToShow = systemScripts.devnetScripts
+      break;
+    default:
+      scriptsToShow = []
+  }
 
   scriptsToShow.forEach(script => {
     locks[getScriptId(script)] = {

--- a/packages/app/src/utils/const.ts
+++ b/packages/app/src/utils/const.ts
@@ -9,6 +9,8 @@ export const ANYONE_CAN_PAY_TESTNET_TX_HASH = '0x4f32b3e39bd1b6350d326fdfafdfe05
 export const SECP256K1_BLAKE160_CODE_HASH = '0x9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8'
 export const SECP256K1_BLAKE160_TESTNET_TX_HASH = '0xf8de3bb47d055cdf460d93a2a6e1b05f7432f9777c8c474abf4eec1d4aee5d37'
 export const SECP256K1_BLAKE160_MAINNET_TX_HASH = '0x71a7ba8fc96349fea0ed3a5c47992e3b4084b031a42264a018e0072e8172e46c'
+export const SECP256K1_BLAKE160_DEVNET_TX_HASH = '0xace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708'
 
 export const RICH_NODE_MAINNET_INDEXER_URL = 'https://prototype.ckbapp.dev/mainnet/indexer'
 export const RICH_NODE_TESTNET_INDEXER_URL = 'https://prototype.ckbapp.dev/testnet/indexer'
+export const RICH_NODE_DEVNET_INDEXER_URL = 'http://localhost:8114/indexer'


### PR DESCRIPTION
Before it's only support main net and test net develop, so I add dev net develop support.
- - -
### Devnet develop tutorial
1. Clone https://github.com/xxuejie/perkins-tent
2. Run `docker run -e CKB_NETWORK=dev --rm -p 8114:9115 -v ~/.ckb-docker-devnet:/data xxuejie/perkins-tent`
3. Go to `~/.ckb-docker-devnet/confs/nginx.conf` change `location = /indexer_rpc` to `location = /indexer`
4. If you want to run miner, append ` miner: ckb miner -C /data/ckb-data` to `~/.ckb-docker-devnet/confs/Procfile`
